### PR TITLE
Don't mutate URL argument

### DIFF
--- a/url.js
+++ b/url.js
@@ -467,7 +467,9 @@
     if (base !== undefined && !(base instanceof jURL))
       base = new jURL(String(base));
 
-    this._url = url;
+    url = String(url)
+
+    this._url = url
     clear.call(this);
 
     var input = url.replace(/^[ \t\r\n\f]+|[ \t\r\n\f]+$/g, '');


### PR DESCRIPTION
The following would cause the location bar to redirect to a regex in Safari:

```js
new URL(window.location)
```

Even though URL's constructor is supposed to take a string, the above works properly in Chrome.

This PR makes sure that the polyfill is always working with a String. I was able to verify it worked properly in the web inspector (didn't see a place to run unit tests like this).

cc @josh @mislav 